### PR TITLE
Fix webkit config to avoid video&photo capture to be opened outside webview layout

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Internal/Views/WebView.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Views/WebView.swift
@@ -7,12 +7,19 @@ struct WebView: UIViewRepresentable {
     var onFinish: ((FinishJourneyResult) -> Void)?
 
     func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        return webView
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
-        webView.load(URLRequest(url: URL(string: url)!))
         webView.navigationDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = false
+        webView.scrollView.bounces = false
+
+        webView.load(URLRequest(url: URL(string: url)!))
     }
 
     func makeCoordinator() -> Coodinator {


### PR DESCRIPTION
## Context/Background

A bug was causing in some plugins which uses media playback to capture IDs to not being able to complete the capture, due to playback was being redirected to be opened outside of the webview and using the native iOS player, which is not correct for this kind of behavior.

## Description of the Change

This PR addresses this. Now the playback occurs inline and behind the plugin layout, so it works properly.

## Steps To Test

- Build the project and install the example app
- Start the journey with Veriff plugin

## Possible Drawbacks

No possible drawbacks have been found
