### PR TITLE
Feature/sc-118311/issues-with-production-false-sandbox-in-ios

### DIFF
--- a/Example/AlloyCodelessLiteiOSDemo/ContentView.swift
+++ b/Example/AlloyCodelessLiteiOSDemo/ContentView.swift
@@ -79,7 +79,7 @@ struct ContentView: View {
                             let entities = EntityData(entities: [entityPerson, entityPerson2], additionalEntities: false)
                             // *** this key is part of a working example ***
                             // You should obtain your journey token from the journey's list
-                            let journeySettings = JourneySettings(journeyToken: "J-UMEhLDP3p759425pz1uP", entities: entities)
+                            let journeySettings = JourneySettings(journeyToken: "J-UMEhLDP3p759425pz1uP", entities: entities, production: false)
                             let journeyResult = try await AlloyCodelessLiteiOS.shared.startJourney(journeySettings: journeySettings, onFinish: { _ in
                                 showResultJourney.toggle()
                             })

--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
@@ -15,8 +15,8 @@ public class AlloySettings {
     // Configure SDK with production environment (default is false)
     public var production = false
 
-    // Configure SDK for make tests in environment (default is false)
-    public var realProduction = false
+    // Configure SDK for make tests in environment (default is true)
+    public var realProduction = true
 
     public var codelessFinalValidation = false
 

--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/JourneySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/JourneySettings.swift
@@ -10,12 +10,13 @@ public class JourneySettings {
 
     public var journeyToken: String = ""
     public var entities: EntityData = EntityData(entities: [], additionalEntities: false)
-
+    public var production: Bool = false;
     init() {}
 
-    public init(journeyToken: String, entities: EntityData) {
+    public init(journeyToken: String, entities: EntityData, production: Bool) {
         self.journeyToken = journeyToken
         self.entities = entities
+        self.production = production
     }
 
     public func getFirstNameEntity(withIndex i: Int) -> String {

--- a/Sources/alloy-codeless-lite-ios/Internal/Network/Endpoints/JourneyEndpoint.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Network/Endpoints/JourneyEndpoint.swift
@@ -50,12 +50,12 @@
             headers.add(HTTPHeader.authorization(bearerToken: TokenHolder.tokens.accessToken))
 
             switch self {
-            case .createJourney:
+            case .createJourney(_, let journeySettings):
                 headers.add(name:"alloy-journey-override-sync", value: "true")
+                headers.add(name:"alloy-sandbox", value: "\(!journeySettings.production)")
             default:
                 break
             }
-
             return headers
 
         }

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
@@ -7,14 +7,16 @@ internal struct PluginURLBuilder {
     var apiKey: String
     var journeyToken: String
     var applicationToken: String
+    var production: Bool
 
-    init(apiKey: String, journeyToken: String, applicationToken: String) {
+    init(apiKey: String, journeyToken: String, applicationToken: String, production: Bool) {
         self.apiKey = apiKey
         self.journeyToken = journeyToken
         self.applicationToken = applicationToken
+        self.production = production && false
     }
 
     public func getPluginURL() -> String {
-        baseUrl  + "journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)"
+        baseUrl  + "journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)"
     }
 }

--- a/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
+++ b/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
@@ -20,7 +20,8 @@ internal struct JourneyService {
             let urlPlugin = PluginURLBuilder(
                 apiKey: AlloyCodelessLiteiOS.shared.alloySettings.apiKey ?? "",
                 journeyToken: journeySettings.journeyToken,
-                applicationToken: TokenHolder.tokens.journeyApplicationToken
+                applicationToken: TokenHolder.tokens.journeyApplicationToken,
+                production: journeySettings.production
             )
             UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
         }
@@ -50,7 +51,8 @@ internal struct JourneyService {
             let urlPlugin = PluginURLBuilder(
                 apiKey: AlloyCodelessLiteiOS.shared.alloySettings.apiKey ?? "",
                 journeyToken: journeySettings.journeyToken,
-                applicationToken: TokenHolder.tokens.journeyApplicationToken
+                applicationToken: TokenHolder.tokens.journeyApplicationToken,
+                production: journeySettings.production
             )
             await UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
         }


### PR DESCRIPTION
## Context/Background

production = false as part of the SDK settings should trigger using sandbox across the board. 
This PR intents to correct this issue.

## Description of the Change

Carry on the production setting across the board.

## Steps To Test

Put production=false and check the journey is on sandbox.

## Testing

We will use the alloy company slug in production to test this change against using PROVE.

## Possible Drawbacks

This will require using the parameter production=true|false as part of the SDK settings. It's not defaulting. So if someone is using this package updating the version automatically, will have a compilation error that will be simple to correct.
