### PR TITLE
Feature/sc-118986/make-sdk-more-flexible-creating-journeys

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
@@ -19,14 +19,17 @@ public class AlloySettings {
     public var realProduction = true
 
     public var codelessFinalValidation = false
+    
+    public var showHeader: Bool? = true
 
     public init() {}
 
-    public init(apiKey: String? = nil, production: Bool = false, realProduction: Bool = false, codelessFinalValidation: Bool = false) {
+    public init(apiKey: String? = nil, production: Bool = false, realProduction: Bool = false, codelessFinalValidation: Bool = false, showHeader: Bool? = true) {
         self.apiKey = apiKey
         self.production = production
         self.realProduction = realProduction
         self.codelessFinalValidation = codelessFinalValidation
+        self.showHeader = showHeader
     }
 
 }

--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/JourneySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/JourneySettings.swift
@@ -18,13 +18,4 @@ public class JourneySettings {
         self.entities = entities
         self.production = production
     }
-
-    public func getFirstNameEntity(withIndex i: Int) -> String {
-        return entities.entities[i].entityData.nameFirst
-    }
-
-    public func getLastNameEntity(withIndex i: Int) -> String {
-        return entities.entities[i].entityData.nameLast
-
-    }
 }

--- a/Sources/alloy-codeless-lite-ios/Internal/Network/Endpoints/Model/Journeys/Request/Entity.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Network/Endpoints/Model/Journeys/Request/Entity.swift
@@ -9,8 +9,8 @@ import Foundation
 public struct Entity: Codable {
 
     public struct EntityData: Codable {
-        public let nameFirst: String
-        public let nameLast: String
+        public let nameFirst: String?
+        public let nameLast: String?
         public let  nameMiddle: String?
         public let  phoneNumber: String?
         public let  emailAddress: String?
@@ -52,8 +52,8 @@ public struct Entity: Codable {
         // MARK: Initializers
 
         public init(
-            nameFirst: String,
-            nameLast: String,
+            nameFirst: String? = nil,
+            nameLast: String? = nil,
             nameMiddle: String? = nil,
             phoneNumber: String? = nil,
             emailAddress: String? = nil,
@@ -90,8 +90,8 @@ public struct Entity: Codable {
 
         public init(from decoder: Decoder) throws {
             let values = try decoder.container(keyedBy: CodingKeys.self)
-            nameFirst = try values.decode(String.self, forKey: .nameFirst)
-            nameLast = try values.decode(String.self, forKey: .nameLast)
+            nameFirst = try values.decodeIfPresent(String.self, forKey: .nameFirst)
+            nameLast = try values.decodeIfPresent(String.self, forKey: .nameLast)
             nameMiddle = try values.decodeIfPresent(String.self, forKey: .nameMiddle)
             phoneNumber = try values.decodeIfPresent(String.self, forKey: .phoneNumber)
             emailAddress = try values.decodeIfPresent(String.self, forKey: .emailAddress)

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
@@ -8,15 +8,17 @@ internal struct PluginURLBuilder {
     var journeyToken: String
     var applicationToken: String
     var production: Bool
+    var showHeader: Bool
 
-    init(apiKey: String, journeyToken: String, applicationToken: String, production: Bool) {
+    init(apiKey: String, journeyToken: String, applicationToken: String, production: Bool, showHeader: Bool) {
         self.apiKey = apiKey
         self.journeyToken = journeyToken
         self.applicationToken = applicationToken
         self.production = production && false
+        self.showHeader = showHeader && true
     }
 
     public func getPluginURL() -> String {
-        baseUrl  + "journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)"
+        baseUrl  + "journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)&showHeader=\(showHeader)"
     }
 }

--- a/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
+++ b/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
@@ -21,7 +21,8 @@ internal struct JourneyService {
                 apiKey: AlloyCodelessLiteiOS.shared.alloySettings.apiKey ?? "",
                 journeyToken: journeySettings.journeyToken,
                 applicationToken: TokenHolder.tokens.journeyApplicationToken,
-                production: journeySettings.production
+                production: journeySettings.production,
+                showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true
             )
             UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
         }
@@ -52,7 +53,8 @@ internal struct JourneyService {
                 apiKey: AlloyCodelessLiteiOS.shared.alloySettings.apiKey ?? "",
                 journeyToken: journeySettings.journeyToken,
                 applicationToken: TokenHolder.tokens.journeyApplicationToken,
-                production: journeySettings.production
+                production: journeySettings.production,
+                showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true
             )
             await UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
         }


### PR DESCRIPTION
## Context/Background

The objective of this PR is:
- Make SDK to not demand first and last names while creating entities.
- Make the showHeader option be present on the AlloySettings.

## Description of the Change

1) Added showHeader as an option on the SDK settings and added it to the build URL.
2) First and Last name are no longer required.


## Steps To Test

Run this locally and set yourself up with only one entity on the branch "prove". Create the entity without any fields on it.

## Testing

Tested on the the device with the original example and with examples fitting this use case. Seems to be working as expected.

## Possible Drawbacks

None. This is already an issue for the customer implementing this SDK.

## Security & Privacy

n/a