### PR TITLE
Feature/sc-120818/add-iswebview-to-params

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 internal struct PluginURLBuilder {
 
-    let baseUrl = "https://alloysdk.alloy.co/?isNext=true&"
+    let baseUrl = "https://alloysdk.alloy.co/?isNext=true&isWebview=true&"
     var apiKey: String
     var journeyToken: String
     var applicationToken: String


### PR DESCRIPTION
## Context/Background

We changed SDK to have a special behavior for mobile by adding isWebview=true

## Description of the Change

isWebview=true as default on the query builder

## Steps To Test

We will test is the production. If the code is out of sync, this will do nothing, but will not affect the current behavior.

## Testing

n/a

## Possible Drawbacks

None.

## Security & Privacy

n/a