### PR TITLE
Support Sending Custom Entity Data in the Initialization of the iOS SDK

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Internal/Network/Endpoints/Model/Journeys/Request/Entity.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Network/Endpoints/Model/Journeys/Request/Entity.swift
@@ -26,6 +26,7 @@ public struct Entity: Codable {
         public let  documentLicense: String?
         public let  documentPassport: String?
         public let  gender: String?
+        public let  additionalData: [String:String]?
 
         // MARK: CodingKeys
 
@@ -47,6 +48,7 @@ public struct Entity: Codable {
             case documentLicense = "document_license"
             case documentPassport = "document_passport"
             case gender = "gender"
+            case additionalData = "additionalData"
         }
 
         // MARK: Initializers
@@ -68,7 +70,8 @@ public struct Entity: Codable {
             documentIdCard: String? = nil,
             documentLicense: String? = nil,
             documentPassport: String? = nil,
-            gender: String? = nil) {
+            gender: String? = nil,
+            additionalData: [String:String]? = nil) {
             self.nameFirst = nameFirst
             self.nameLast = nameLast
             self.nameMiddle = nameMiddle
@@ -86,6 +89,7 @@ public struct Entity: Codable {
             self.documentLicense = documentLicense
             self.documentPassport = documentPassport
             self.gender = gender
+            self.additionalData = additionalData
         }
 
         public init(from decoder: Decoder) throws {
@@ -107,6 +111,7 @@ public struct Entity: Codable {
             documentLicense = try values.decodeIfPresent(String.self, forKey: .documentLicense)
             documentPassport = try values.decodeIfPresent(String.self, forKey: .documentPassport)
             gender = try values.decodeIfPresent(String.self, forKey: .gender)
+            additionalData = try values.decodeIfPresent(Dictionary.self, forKey: .additionalData)
         }
     }
 


### PR DESCRIPTION
<!--

*------- PR Requirements -------*

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must have a Clubhouse ticket attached. We're trying to make sure all changes are requested and tracked, so make sure there is a ticket!
* The pull request must update the test suite to exercise the updated functionality. 
* After you create the pull request, all status checks must pass before a maintainer reviews your contribution.

*------------------------------*

-->

## Context/Background

Needed a way to add additional data to an entity
<!--

Include any context not present in the ticket. If your change touches many areas of the code, include an overview of those areas.

-->

## Description of the Change

Added additionalData variable to entity model, this accepts a dictionary of string keys and string content and will be sent in the additionalData attribute.

![IMG_8370](https://github.com/UseAlloy/alloy-codeless-lite-ios/assets/117905757/1bd509c2-e75f-4aa5-9593-be8916bd4301)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

It is often helpful to show a before/after screenshot or gif/video; Markdown tables can help make those readable, like so:
| Before                               | After                                |
| :----------------------------------- | :----------------------------------- |
| ![](http://before.image.link)        | ![](http://url.for.after.image)      |
| ![](https://i.imgur.com/XFqHtXE.jpg) | ![](https://i.imgur.com/XFqHtXE.jpg) |

<details open>
  <summary>collapsable sections</summary>
  You can also create collapsable sections for greater detail. These can include Markdown.
</details>

-->

## Steps To Test

1- Added custom attributes to one of the entities in the Example
2- Ran the example app and started a journey
2- Used a proxy to monitor the api call and see if the data was sent
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

This lets reviewers check that you've considered all the cases your code could touch.

-->

## Testing

N/A
<!--

What automated tests do we have around this change?

- If it is new code, are all parts tested?
- If changing existing code, did you have to update any tests?
- If changing existing code, did you add tests to cover the change?

Also, if you are touching old code, did you add additional tests, cause additional tests makes everyone happy!

Remember, types of tests you can have:

- unit tests
- integrations tests
- end to end tests

-->

## Possible Drawbacks
AditionalData attribute expects a string as content of dictonary
<!-- What are the possible side-effects or negative impacts of the code change? -->

## Security & Privacy

AdditionalData can now receive any amount of extra parameters, this could cause problems in some extreme cases but the possibility of this being a a problem is negligible
<!-- Any significant security related changes/concerns to note. This includes changes to authentication/authorization, data privacy, networking, major configuration changes, among others. 

For example, 
- this change enables a feature flag will allow users with the `xyz` role to make config changes
- this change makes the cluster accessible to a specific VPC

-->

<!--
Notes:

Try to keep your PR under 500 LOC. If your change is large, group it into PRs based on logical areas (adding a component, adding an API endpoint, etc).

-->
