### PR TITLE
Changed dismiss so that it only dismisses the last view controller

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Internal/Views/WebView.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Views/WebView.swift
@@ -34,6 +34,7 @@ struct WebView: UIViewRepresentable {
             self.parent = parent
         }
 
+        @MainActor
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             if let host = navigationAction.request.url?.host {
                 if host.contains("exit") {
@@ -41,7 +42,7 @@ struct WebView: UIViewRepresentable {
                     if let completion = parent.onFinish {
                         completion(FinishJourneyResult(finishResultCode: .FINISH_RESULT_COMPLETED, finishResultMessage: "", journeyResultData: nil))
                     }
-                    self.parent.dismiss()
+                    UIUtils.dismissCurrentView()
                     return
                 }
             }

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/UIUtils.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/UIUtils.swift
@@ -10,6 +10,15 @@ import UIKit
 internal struct UIUtils {
 
     @MainActor
+    static func dismissCurrentView() {
+        UIApplication
+            .shared
+            .connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .last?.rootViewController?.presentedViewController?.dismiss(animated: true)
+    }
+    
+    @MainActor
     static func presentView(viewController: UIHostingController<some View>, presentationStyle: UIModalPresentationStyle) {
         let topViewController = UIUtils.topMostController()
         viewController.modalPresentationStyle = presentationStyle

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/View.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/View.swift
@@ -15,13 +15,5 @@ internal extension View {
             self
         }
     }
-
-    func dismiss() {
-        UIApplication
-            .shared
-            .keyWindow?
-            .rootViewController?
-            .dismiss(animated: true, completion: nil)
-    }
 }
 


### PR DESCRIPTION
<!--

*------- PR Requirements -------*

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must have a Clubhouse ticket attached. We're trying to make sure all changes are requested and tracked, so make sure there is a ticket!
* The pull request must update the test suite to exercise the updated functionality. 
* After you create the pull request, all status checks must pass before a maintainer reviews your contribution.

*------------------------------*

-->

## Context/Background

Client was having problem with the skd, the underlying views of the app were being dismissed when calling dismiss from the sdk.

<!--

Include any context not present in the ticket. If your change touches many areas of the code, include an overview of those areas.

-->

## Description of the Change

Changed the dissmiss function from an extension of view to a static func on UiUtils. Also changed the target viewcontroller that was told to dismiss to the presentedviewcontroller, this should prevent the dismissal of unrelated views.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

It is often helpful to show a before/after screenshot or gif/video; Markdown tables can help make those readable, like so:
| Before                               | After                                |
| :----------------------------------- | :----------------------------------- |
| ![](http://before.image.link)        | ![](http://url.for.after.image)      |
| ![](https://i.imgur.com/XFqHtXE.jpg) | ![](https://i.imgur.com/XFqHtXE.jpg) |

<details open>
  <summary>collapsable sections</summary>
  You can also create collapsable sections for greater detail. These can include Markdown.
</details>

-->

## Steps To Test

The client must test it on their implementation, also tested locally on the test project.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

This lets reviewers check that you've considered all the cases your code could touch.

-->

## Testing

N/A

<!--

What automated tests do we have around this change?

- If it is new code, are all parts tested?
- If changing existing code, did you have to update any tests?
- If changing existing code, did you add tests to cover the change?

Also, if you are touching old code, did you add additional tests, cause additional tests makes everyone happy!

Remember, types of tests you can have:

- unit tests
- integrations tests
- end to end tests

-->

## Possible Drawbacks

None

<!-- What are the possible side-effects or negative impacts of the code change? -->

## Security & Privacy

No concerns

<!-- Any significant security related changes/concerns to note. This includes changes to authentication/authorization, data privacy, networking, major configuration changes, among others. 

For example, 
- this change enables a feature flag will allow users with the `xyz` role to make config changes
- this change makes the cluster accessible to a specific VPC

-->

<!--
Notes:

Try to keep your PR under 500 LOC. If your change is large, group it into PRs based on logical areas (adding a component, adding an API endpoint, etc).

-->
