### PR TITLE
Task/CONNECT1-948/make-sdk-work-with-lower-i-os-versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@
         name: "alloy-codeless-lite-ios",
         defaultLocalization: "en",
         platforms: [
-            .iOS(.v16)
+            .iOS(.v13)
         ],
         products: [
             // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/UIUtils.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/UIUtils.swift
@@ -10,12 +10,15 @@ import UIKit
 internal struct UIUtils {
 
     @MainActor
-    static func dismissCurrentView() {
-        UIApplication
-            .shared
-            .connectedScenes
-            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-            .last?.rootViewController?.presentedViewController?.dismiss(animated: true)
+    static func dismissCurrentView() {        
+        if let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
+           let rootViewController = window.rootViewController {
+            var presentedViewController = rootViewController
+            while let nextPresentedViewController = presentedViewController.presentedViewController {
+                presentedViewController = nextPresentedViewController
+            }
+            presentedViewController.dismiss(animated: true, completion: nil)
+        }
     }
     
     @MainActor

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/UIUtils.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/UIUtils.swift
@@ -10,14 +10,22 @@ import UIKit
 internal struct UIUtils {
 
     @MainActor
-    static func dismissCurrentView() {        
-        if let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
-           let rootViewController = window.rootViewController {
-            var presentedViewController = rootViewController
-            while let nextPresentedViewController = presentedViewController.presentedViewController {
-                presentedViewController = nextPresentedViewController
-            }
-            presentedViewController.dismiss(animated: true, completion: nil)
+    static func dismissCurrentView() {
+        if #available(iOS 15.0, *) {
+            UIApplication
+                .shared
+                .connectedScenes
+                .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+                .last?.rootViewController?.presentedViewController?.dismiss(animated: true)
+        } else {
+            UIApplication
+                .shared
+                .connectedScenes
+                .compactMap { ($0 as? UIWindowScene)?.windows.first(where: { $0.isKeyWindow }) }
+                .last?
+                .rootViewController?
+                .presentedViewController?
+                .dismiss(animated: true)
         }
     }
     


### PR DESCRIPTION
## Context/Background

The purpose of this PR is make the minimum iOS requirement to be 13 instead of 16.

## Description of the Change

* Downgrade the required min version of iOS.
* Changed the dismissWindows process to be compatible with what it's supported on iOS13.

## Steps To Test

- Download the quick-ios-app from alloy-samples.
- Update the package to the latest version. 
- Run it and dismiss a window.


## Testing

N/A

## Possible Drawbacks

The is risk that the dismiss window may have unintended effects on certain configurations. But it's impossible to test without knowing how is been used.

## Security & Privacy

N/A