### PR TITLE
Bug/CONNECT1-1397/i-os-and-android-sdk-packages-not-working-in-eu-cell

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
@@ -23,16 +23,28 @@ public class AlloySettings {
     public var showHeader: Bool? = true
     
     public var showDebugInfo: Bool = false
+    
+    public var  journeyToken: String?
+    
+    public var journeyApplicationToken: String?
+    
+    public var appUrl: String = "https://corekube-prod-alloysdk.app.alloy.com"
+    
+    public var apiUrl: String = "https://corekube-prod-alloysdk.api.alloy.com"
 
     public init() {}
 
-    public init(apiKey: String? = nil, production: Bool = false, realProduction: Bool = false, codelessFinalValidation: Bool = false, showHeader: Bool? = true, showDebugInfo: Bool = false) {
+    public init(apiKey: String? = nil, production: Bool = false, realProduction: Bool = false, codelessFinalValidation: Bool = false, showHeader: Bool? = true, showDebugInfo: Bool = false, journeyToken: String, journeyApplicationToken: String?, appUrl: String? = nil, apiUrl: String? = nil) {
         self.apiKey = apiKey
         self.production = production
         self.realProduction = realProduction
         self.codelessFinalValidation = codelessFinalValidation
         self.showHeader = showHeader
         self.showDebugInfo = showDebugInfo
+        self.journeyToken = journeyToken
+        self.journeyApplicationToken = journeyApplicationToken
+        self.appUrl = appUrl ?? "https://corekube-prod-alloysdk.app.alloy.com"
+        self.apiUrl = apiUrl ?? "https://corekube-prod-alloysdk.api.alloy.com"
     }
 
 }

--- a/Sources/alloy-codeless-lite-ios/Internal/Network/URLs.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Network/URLs.swift
@@ -9,10 +9,7 @@ import Foundation
 internal struct URLs {
     
     static func getApi(_ alloySettings: AlloySettings) -> String {
-        if alloySettings.realProduction {
-            return "https://docv.alloy.co"
-        }
-        return "https://docv-dev-api.alloy.co/"
+        return alloySettings.apiUrl
     }
-    
+
 }

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
@@ -3,22 +3,23 @@ import SwiftUI
 
 internal struct PluginURLBuilder {
 
-    let baseUrl = "https://alloysdk.alloy.co/?isNext=true&isWebview=true&"
     var apiKey: String
     var journeyToken: String
     var applicationToken: String
     var production: Bool
     var showHeader: Bool
+    var appUrl: String
 
-    init(apiKey: String, journeyToken: String, applicationToken: String, production: Bool, showHeader: Bool) {
+    init(apiKey: String, journeyToken: String, applicationToken: String, production: Bool, showHeader: Bool, appUrl: String) {
         self.apiKey = apiKey
         self.journeyToken = journeyToken
         self.applicationToken = applicationToken
         self.production = production && false
         self.showHeader = showHeader && true
+        self.appUrl = appUrl
     }
 
     public func getPluginURL() -> String {
-        baseUrl  + "journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)&showHeader=\(showHeader)"
+        appUrl  + "/?isWebview=true&journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)&showHeader=\(showHeader)"
     }
 }

--- a/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
+++ b/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
@@ -27,7 +27,8 @@ internal struct JourneyService {
                 journeyToken: journeySettings.journeyToken,
                 applicationToken: TokenHolder.tokens.journeyApplicationToken,
                 production: journeySettings.production,
-                showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true
+                showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true,
+                appUrl: AlloyCodelessLiteiOS.shared.alloySettings.appUrl
             )
             UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
         }
@@ -59,7 +60,8 @@ internal struct JourneyService {
                 journeyToken: journeySettings.journeyToken,
                 applicationToken: TokenHolder.tokens.journeyApplicationToken,
                 production: journeySettings.production,
-                showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true
+                showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true,
+                appUrl: AlloyCodelessLiteiOS.shared.alloySettings.appUrl
             )
             await UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
         }


### PR DESCRIPTION
## Context/Background

The package for iOS didn't contemplate the multiple cells approach that we incorporate to the Alloy architecuture.
This PR intends to fix that.

## Description of the Change

- Added the appURL and apiURL to the alloy settings.
- Default to the main cell environment.

## Steps To Test

Run an example on this branch with the following settings:

```
apiKey: "6e62be50-ea4f-4901-97a7-bbc4d910ed8b",
journeyToken: "J-ZjDs6QEFFF26ebZsp22a",
journeyApplicationToken: "JA-KWv7bRzdeI7VwZRVWO7k",
appUrl: "https://shared-prod-ew1-01-alloysdk.app.alloy.com/",
apiUrl: "https://shared-prod-ew1-01-alloysdk.api.alloy.com/"
```

Also run an example without them.

## Testing

N/A

## Possible Drawbacks

None if tested with current settings.

## Security & Privacy

N/A
