### PR TITLE
bug/CONNECT1-1470/improve-public-properties-on-ios-to-mimic-what-ig-is-doing-on-the-web

### DIFF
--- a/Example/AlloyCodelessLiteiOSDemo/ContentView.swift
+++ b/Example/AlloyCodelessLiteiOSDemo/ContentView.swift
@@ -34,11 +34,18 @@ struct ContentView: View {
                             // *** this key is part of a working example ***
                             // You should obtain your key from the alloy dashboard
                             // On settings > SDK Config
-                            apiKey: "9ca83767-f213-4aaf-bc1b-1ed0a89eaf23", 
+                            apiKey: "679663b8-d73a-423b-80e9-3ac8ec698c3c",
                             production: false,
                             realProduction: true,
                             codelessFinalValidation: false,
-                            showDebugInfo: true
+                            showHeader: false,
+                            showDebugInfo: true,
+                            journeyToken: "J-72ADYuJif7FOiDsYZoRE",
+                            journeyApplicationToken: "JA-u1O0Xy7dhhdSjqcfSQQk",
+                            appUrl: "https://corekube-dev-alloysdk.app.alloy.com",
+                            apiUrl: "https://corekube-dev-alloysdk.api.alloy.com",
+                            entityToken: "P-CvoABf21aramOazpQoM4",
+                            isSingleEntity:true
                         )
 
                         let authInitResult: AuthInitResult = try await AlloyCodelessLiteiOS.shared.authInit(alloySettings: alloySettings)
@@ -67,22 +74,10 @@ struct ContentView: View {
                     Task {
                         if !resumeJourney {
                             resumeJourney.toggle()
-                            // We are creating 2 entities for the journey application using only first and last name.
-                            // The Entity data needed will vary depending on the services associated to your workflows.
-                            let entityDataPerson = Entity.EntityData(nameFirst: "John", nameLast: "Doe", phoneNumber: "5555555555", emailAddress: "test@test.com", documentSsn: "111111112")
-                            let entityDataPerson2 = Entity.EntityData(nameFirst: "Julie", nameLast: "Tam", addressCountryCode: "US", documentSsn: "111111111")
-                            // We add the entity data to an entity structure. Entity type can be person or business
-                            // The branch name needs to match the branch names on your journey.
-                            // If you only have one branch, you don't need to pass a branch name.
-                            let entityPerson = Entity(entityData: entityDataPerson, entityType: "person", branchName: "vouched", externalEntityId: "EX-1234x")
-                            let entityPerson2 = Entity(entityData: entityDataPerson2, entityType: "person", branchName: "veriff", externalEntityId: "EX-5678x")
-
-                            let entities = EntityData(entities: [entityPerson, entityPerson2], additionalEntities: false)
-                            // *** this key is part of a working example ***
-                            // You should obtain your journey token from the journey's list
+                           
                             let journeySettings = JourneySettings(
-                                journeyToken: "J-UMEhLDP3p759425pz1uP",
-                                entities: entities,
+                                journeyToken: "J-72ADYuJif7FOiDsYZoRE",
+                                journeyApplicationToken: "JA-u1O0Xy7dhhdSjqcfSQQk",
                                 production: false,
                                 showDebugInfo: true
                             )

--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
@@ -31,10 +31,14 @@ public class AlloySettings {
     public var appUrl: String = "https://corekube-prod-alloysdk.app.alloy.com"
     
     public var apiUrl: String = "https://corekube-prod-alloysdk.api.alloy.com"
+    
+    public var entityToken: String?
+    
+    public var isSingleEntity: Bool = false
 
     public init() {}
 
-    public init(apiKey: String? = nil, production: Bool = false, realProduction: Bool = false, codelessFinalValidation: Bool = false, showHeader: Bool? = true, showDebugInfo: Bool = false, journeyToken: String, journeyApplicationToken: String?, appUrl: String? = nil, apiUrl: String? = nil) {
+    public init(apiKey: String? = nil, production: Bool = false, realProduction: Bool = false, codelessFinalValidation: Bool = false, showHeader: Bool? = true, showDebugInfo: Bool = false, journeyToken: String, journeyApplicationToken: String?, appUrl: String? = nil, apiUrl: String? = nil, entityToken: String? = nil, isSingleEntity: Bool = false) {
         self.apiKey = apiKey
         self.production = production
         self.realProduction = realProduction
@@ -45,6 +49,8 @@ public class AlloySettings {
         self.journeyApplicationToken = journeyApplicationToken
         self.appUrl = appUrl ?? "https://corekube-prod-alloysdk.app.alloy.com"
         self.apiUrl = apiUrl ?? "https://corekube-prod-alloysdk.api.alloy.com"
+        self.entityToken = entityToken
+        self.isSingleEntity = isSingleEntity
     }
 
 }

--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/AlloySettings.swift
@@ -24,7 +24,7 @@ public class AlloySettings {
     
     public var showDebugInfo: Bool = false
     
-    public var  journeyToken: String?
+    public var journeyToken: String?
     
     public var journeyApplicationToken: String?
     

--- a/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
+++ b/Sources/alloy-codeless-lite-ios/Public/Utility/PluginURLBuilde.swift
@@ -6,20 +6,29 @@ internal struct PluginURLBuilder {
     var apiKey: String
     var journeyToken: String
     var applicationToken: String
+    var entityToken: String
+    var isSingleEntity: Bool
     var production: Bool
     var showHeader: Bool
     var appUrl: String
 
-    init(apiKey: String, journeyToken: String, applicationToken: String, production: Bool, showHeader: Bool, appUrl: String) {
+    init(apiKey: String, journeyToken: String, applicationToken: String, entityToken: String,
+         isSingleEntity: Bool, production: Bool, showHeader: Bool, appUrl: String) {
         self.apiKey = apiKey
         self.journeyToken = journeyToken
         self.applicationToken = applicationToken
+        self.entityToken = entityToken
+        self.isSingleEntity = isSingleEntity
         self.production = production && false
         self.showHeader = showHeader && true
         self.appUrl = appUrl
+       
     }
 
     public func getPluginURL() -> String {
-        appUrl  + "/?isWebview=true&journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)&showHeader=\(showHeader)"
+        var finalUrl = appUrl  + "/?isWebview=true&journeyApplicationToken=\(applicationToken)&journeyToken=\(journeyToken)&key=\(apiKey)&production=\(production)&showHeader=\(showHeader)"
+        if (entityToken != "") { finalUrl += "&entityToken=\(entityToken)" }
+        if (isSingleEntity == true) { finalUrl += "&singleEntity=true" }
+        return finalUrl
     }
 }

--- a/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
+++ b/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
@@ -26,6 +26,8 @@ internal struct JourneyService {
                 apiKey: AlloyCodelessLiteiOS.shared.alloySettings.apiKey ?? "",
                 journeyToken: journeySettings.journeyToken,
                 applicationToken: TokenHolder.tokens.journeyApplicationToken,
+                entityToken: AlloyCodelessLiteiOS.shared.alloySettings.entityToken ?? "",
+                isSingleEntity: AlloyCodelessLiteiOS.shared.alloySettings.isSingleEntity,
                 production: journeySettings.production,
                 showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true,
                 appUrl: AlloyCodelessLiteiOS.shared.alloySettings.appUrl
@@ -59,6 +61,8 @@ internal struct JourneyService {
                 apiKey: AlloyCodelessLiteiOS.shared.alloySettings.apiKey ?? "",
                 journeyToken: journeySettings.journeyToken,
                 applicationToken: TokenHolder.tokens.journeyApplicationToken,
+                entityToken: AlloyCodelessLiteiOS.shared.alloySettings.entityToken ?? "",
+                isSingleEntity: AlloyCodelessLiteiOS.shared.alloySettings.isSingleEntity,
                 production: journeySettings.production,
                 showHeader:  AlloyCodelessLiteiOS.shared.alloySettings.showHeader ?? true,
                 appUrl: AlloyCodelessLiteiOS.shared.alloySettings.appUrl


### PR DESCRIPTION
## Context/Background

After reviewing the package for IOS, we found that isSingleEntity and entityToken were not passed.

## Description of the Change

Added the properties to the class and build the URL with them if available.

## Steps To Test

Test the current project, but add isSingleEntity = true

## Testing

N/A

## Possible Drawbacks

N/A

## Security & Privacy

N/A