### PR TITLE
fix: dismiss does not work on multi-target situations

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
+++ b/Sources/alloy-codeless-lite-ios/Services/JourneyService.swift
@@ -34,7 +34,10 @@ internal struct JourneyService {
                 customTheme: AlloyCodelessLiteiOS.shared.alloySettings.customTheme,
                 componentOverride: AlloyCodelessLiteiOS.shared.alloySettings.componentOverride
             )
-            UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
+
+            guard let topVC = UIUtils.topMostController() else { return result }
+
+            UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish, presenter: topVC), presentationStyle: .overFullScreen)
         }
         return result
     }
@@ -71,7 +74,10 @@ internal struct JourneyService {
                 customTheme:  AlloyCodelessLiteiOS.shared.alloySettings.customTheme,
                 componentOverride: AlloyCodelessLiteiOS.shared.alloySettings.componentOverride
             )
-            await UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish), presentationStyle: .overFullScreen)
+
+            guard let topVC = await UIUtils.topMostController() else { return }
+
+            await UIUtils.presentView(viewController: WebViewController(url: urlPlugin.getPluginURL(), onFinish: onFinish, presenter: topVC), presentationStyle: .overFullScreen)
         }
     }
 


### PR DESCRIPTION
## Issue

Previously, the app used a global helper (`UIUtils.dismissCurrentView()`) to locate the “topmost” view controller and dismiss it. In multi-scene or multi-view environments, that approach could target the wrong window or dismiss multiple stacked views, effectively closing more than intended—or even appearing to close the entire app.

## Solution

Instead of guessing the topmost view controller, we now pass a direct reference to the presenter into the WebViewController. When the web view finishes, it sends the `dismiss` command to the appropriate controller.