### PR TITLE
Task/DPI-2531/adding-hide-previous-button-icon-to-the-ios-package

### DIFF
--- a/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/CustomStyle.swift
+++ b/Sources/alloy-codeless-lite-ios/Internal/Model/Settings/CustomStyle.swift
@@ -11,8 +11,9 @@ public struct CustomTheme: Codable {
     public var fontFamily: String?
     public var wideMobileButtons: Bool?
     public var alignContentStart: Bool?
+    public var hidePreviousButtonIcon: Bool?
     
-    public init(primaryColor: String? = nil, backgroundColor: String? = nil, textColor: String? = nil, borderRadius: String? = nil, iconColor: String? = nil, successColor: String? = nil, errorColor: String? = nil, fontFamily: String? = nil, wideMobileButtons: Bool? = nil, alignContentStart: Bool? = nil) {
+    public init(primaryColor: String? = nil, backgroundColor: String? = nil, textColor: String? = nil, borderRadius: String? = nil, iconColor: String? = nil, successColor: String? = nil, errorColor: String? = nil, fontFamily: String? = nil, wideMobileButtons: Bool? = nil, alignContentStart: Bool? = nil, hidePreviousButtonIcon: Bool? = nil) {
         self.primaryColor = primaryColor
         self.backgroundColor = backgroundColor
         self.textColor = textColor
@@ -23,6 +24,7 @@ public struct CustomTheme: Codable {
         self.fontFamily = fontFamily
         self.wideMobileButtons = wideMobileButtons
         self.alignContentStart = alignContentStart
+        self.hidePreviousButtonIcon = hidePreviousButtonIcon
     }
 }
 


### PR DESCRIPTION
## Context/Background

We recently updated the theme on the SDK to handle a new property hidePreviousButtonIcon that is currently missing on the SDK package for iOS

## Description of the Change

* Added hidePreviousButtonIcon to the constructor class.

## Steps To Test

Run an iOS example with this value.

## Testing

N/A

## Possible Drawbacks

None

## Security & Privacy

No changes on privacy or security
